### PR TITLE
Escape quotes in string values

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -102,7 +102,7 @@ $(document).ready(function () {
 			for (var j = 0; j < oLength; j++) {
 				var currValue = allValues[i][options[j]];
 				if (typeof currValue === "string")
-					sql += "'" + currValue + "', ";
+					sql += "'" + currValue.replace(/\x27/g, '\\\x27') + "', ";
 				else if (typeof currValue === "number")
 					sql += "" + currValue + ", ";
 			}


### PR DESCRIPTION
The current MySQL output is invalid as single quotes inside strings (which are wrapped in single quotes) aren’t escaped properly. This fixed that.
