### PR TITLE
Corrected id references, removed outline from button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,8 @@
-.examplecode {
+#examplecode {
 	display: none;
 	font-size: 12px;
 }
-.generatedcode {
+#generatedcode {
 	border:1px solid #999999;
 	width:100%;
 	margin:5px 0;
@@ -11,4 +11,8 @@
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
+}
+
+#generatecode {
+  outline: none;
 }


### PR DESCRIPTION
By default, bootstrap buttons, have a blueish outline as a border: 
![image](https://cloud.githubusercontent.com/assets/5684688/7812170/9288b0a0-03b8-11e5-9141-7708d80be756.png)

Moreover, the stylesheet referred to id selectors, but used class selectors.
