### PR TITLE
Fix the link for demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ getCountries()
 
 MySQL, Firebird, XML, JSON, CSV or YAML generator for custom Countries data. All the data is fetched from geonames.org
 
-http://peric.github.com/GetCountries
+http://peric.github.io/GetCountries
 
 # Development
 


### PR DESCRIPTION
The link for demo site was not working.
You should fix the link in the "About" section too.